### PR TITLE
Change what we link to

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SOURCES
 
 add_library(luavoce MODULE ${SOURCES})
 set_property(TARGET luavoce PROPERTY PREFIX "")
-target_link_libraries(luavoce ${LUABIND_LIBRARIES} ${JNI_LIBRARIES})
+target_link_libraries(luavoce ${LUABIND_LIBRARIES} ${JAVA_JVM_LIBRARY})
 
 #if(BUILD_TESTING)
 	# if(NOT LUA_COMMAND)


### PR DESCRIPTION
I think this fixes #3 and perhaps also #4 - we were linking to AWT even though we didn't need to.
